### PR TITLE
DIVE-3　Admin（管理者）アカウント管理機能の実装

### DIFF
--- a/app/Http/Controllers/Admin/AdminAccountController.php
+++ b/app/Http/Controllers/Admin/AdminAccountController.php
@@ -37,6 +37,28 @@ class AdminAccountController extends Controller
         session()->flash('flash_message', '管理者アカウントを作成しました。');
         return redirect()->route('admin.account.index');
     }
+    public function edit($id)
+    {
+        $admin = Admin::findOrFail($id);
+        return view('admin.account.edit')->with('admin', $admin);
+    }
+    public function update(Request $request, $id)
+    {
+        $admin = Admin::findOrFail($id);
+        $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+        ]);
+
+        $admin->name = $request->name;
+        $admin->email = strtolower($request->email);
+        if ($request->password) {
+            $admin->password = Hash::make($request->password);
+        }
+        $admin->save();
+
+        session()->flash('flash_message', '管理者アカウントを更新しました。');
+        return redirect()->route('admin.account.index');
+    }
 
     public function destroy($id)
     {

--- a/app/Http/Controllers/Admin/AdminAccountController.php
+++ b/app/Http/Controllers/Admin/AdminAccountController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use App\Http\Controllers\Controller;
+use App\Models\Admin;
+
+class AdminAccountController extends Controller
+{
+    public function index()
+    {
+        $admins = Admin::all();
+        return view('admin.account.index')->with('admins', $admins);
+    }
+
+    public function create()
+    {
+        return view('admin.account.create');
+    }
+    
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:admins'],
+            'password' => ['required', 'confirmed'],
+        ]);
+
+        $admin = Admin::create([
+            'name' => $request->name,
+            'email' => strtolower($request->email),
+            'password' => Hash::make($request->password),
+        ]);
+
+        session()->flash('flash_message', '管理者アカウントを作成しました。');
+        return redirect()->route('admin.account.index');
+    }
+
+    public function destroy($id)
+    {
+        $admin = Admin::findOrFail($id);
+        $admin->delete();
+
+        session()->flash('flash_message', '管理者アカウントを削除しました。');
+        return redirect()->route('admin.account.index');
+    }
+
+}

--- a/app/Http/Controllers/Admin/AdminAccountController.php
+++ b/app/Http/Controllers/Admin/AdminAccountController.php
@@ -30,7 +30,7 @@ class AdminAccountController extends Controller
 
         $admin = Admin::create([
             'name' => $request->name,
-            'email' => strtolower($request->email),
+            'email' => $request->email,
             'password' => Hash::make($request->password),
         ]);
 

--- a/app/View/Components/GuestLayout.php
+++ b/app/View/Components/GuestLayout.php
@@ -12,6 +12,6 @@ class GuestLayout extends Component
      */
     public function render(): View
     {
-        return view('layouts.guest');
+        return view('admin.layouts.guest');
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,23 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.button {
+    background-color: #555c;
+    border: none;
+    color: white;
+    padding-block: 7px 5px;
+    padding-inline: 20px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    border-radius: 10px;
+}
+.button:hover {
+    opacity: 0.5;
+}
+
+.button_edit{
+    padding-inline: 20px
+}

--- a/resources/views/admin/account/create.blade.php
+++ b/resources/views/admin/account/create.blade.php
@@ -1,0 +1,48 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ '管理者アカウント新規作成' }}
+        </h2>
+    </x-slot>
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST" action="{{ route('admin.account.store') }}">
+                @csrf
+                <div>
+                    <x-input-label for="name" :value="__('Name')" />
+                    <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
+                    <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                </div>
+                <div class="mt-4">
+                    <x-input-label for="email" :value="__('Email')" />
+                    <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autocomplete="username" />
+                    <x-input-error :messages="$errors->get('email')" class="mt-2" />
+                </div>
+                <div class="mt-4">
+                    <x-input-label for="password" :value="__('Password')" />
+        
+                    <x-text-input id="password" class="block mt-1 w-full"
+                                    type="password"
+                                    name="password"
+                                    required autocomplete="new-password" />
+                    <x-input-error :messages="$errors->get('password')" class="mt-2" />
+                </div>
+                <div class="mt-4">
+                    <x-input-label for="password_confirmation" :value="__('Confirm Password')" />
+                    <x-text-input id="password_confirmation" class="block mt-1 w-full"
+                                    type="password"
+                                    name="password_confirmation" required autocomplete="new-password" />
+                    <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
+                </div>
+                <div class="flex items-center justify-end mt-4">
+                    <x-secondary-button onclick="location.href='{{ route('admin.account.index') }}'">
+                        {{ __('Cancel') }}
+                    </x-secondary-button>
+                    <x-primary-button class="ml-4">
+                        {{ __('Register') }}
+                    </x-primary-button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/account/edit.blade.php
+++ b/resources/views/admin/account/edit.blade.php
@@ -1,0 +1,27 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ '管理者アカウント編集' }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST"  action="{{ route('admin.account.update', $admin->id) }}">
+                @csrf
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <p>氏名　：<input type="text" name="name" value="{{ $admin->name }}"></p>
+                        <p>メール：<input type="text" name="email" value="{{ $admin->email }}"></p>
+                        <p>パスワード：<input type="password" name="password" value=""></p>
+                        <p>作成日：{{ $admin->created_at }}</p>
+                    </div>
+                    <div class="p-6 text-gray-900">
+                        <input type="button" onclick="location.href='{{ route('admin.account.index') }}'" value="戻る">
+                        <input type="submit" value="更新">
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/account/edit.blade.php
+++ b/resources/views/admin/account/edit.blade.php
@@ -10,15 +10,14 @@
             <form method="POST"  action="{{ route('admin.account.update', $admin->id) }}">
                 @csrf
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                    <div class="p-6 text-gray-900">
-                        <p>氏名　：<input type="text" name="name" value="{{ $admin->name }}"></p>
-                        <p>メール：<input type="text" name="email" value="{{ $admin->email }}"></p>
-                        <p>パスワード：<input type="password" name="password" value=""></p>
-                        <p>作成日：{{ $admin->created_at }}</p>
+                    <div class="p-6 text-gray-900 pb-0">
+                        <p style="margin-bottom: 15px">氏名　　　 ：　<input type="text" name="name" value="{{ $admin->name }}"></p>
+                        <p style="margin-bottom: 15px">メール　　 ：　<input type="text" name="email" value="{{ $admin->email }}"></p>
+                        <p style="margin-bottom: 15px">パスワード ：　<input type="password" name="password" value=""></p>
                     </div>
                     <div class="p-6 text-gray-900">
-                        <input type="button" onclick="location.href='{{ route('admin.account.index') }}'" value="戻る">
-                        <input type="submit" value="更新">
+                        <input class="button" type="button" onclick="location.href='{{ route('admin.account.index') }}'" value="戻る" style="margin-right: 6px">
+                        <input class="button" type="submit" value="更新">
                     </div>
                 </div>
             </form>

--- a/resources/views/admin/account/index.blade.php
+++ b/resources/views/admin/account/index.blade.php
@@ -21,7 +21,7 @@
                         <p>作成日：{{ $admin->created_at }}</p>
                     </div>
                     <div class="p-6 text-gray-900">
-                        {{-- <button type="button" onclick="location.href='{{ route('admin.account.edit', $admin->id) }}'">編集</button> --}}
+                        <button type="button" onclick="location.href='{{ route('admin.account.edit', $admin->id) }}'">編集</button>
                         <form method="POST" action="{{ route('admin.account.destroy', $admin->id) }}" style="display: inline">
                             @csrf
                             @method('DELETE')

--- a/resources/views/admin/account/index.blade.php
+++ b/resources/views/admin/account/index.blade.php
@@ -12,20 +12,20 @@
                     <p class="text-green-500">{{ session('flash_message') }}</p>
                 </div>
             @endif
-            <button type="button" onclick="location.href='{{ route('admin.account.create') }}'">新規作成</button>
+            <div style="text-align: right; margin-bottom:20px">
+                <button class="button" type="button" onclick="location.href='{{ route('admin.account.create') }}'">管理者の新規作成</button>
+            </div>
             @foreach($admins as $admin)
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                     <div class="p-6 text-gray-900">
                         <p>氏名　：{{ $admin->name }}</p>
                         <p>メール：{{ $admin->email }}</p>
-                        <p>作成日：{{ $admin->created_at }}</p>
-                    </div>
-                    <div class="p-6 text-gray-900">
-                        <button type="button" onclick="location.href='{{ route('admin.account.edit', $admin->id) }}'">編集</button>
+                        <p style="margin-bottom: 10px">作成日：{{ $admin->created_at }}</p>
+                        <button class="button" type="button" onclick="location.href='{{ route('admin.account.edit', $admin->id) }}'" style="margin-right: 6px">編集</button>
                         <form method="POST" action="{{ route('admin.account.destroy', $admin->id) }}" style="display: inline">
                             @csrf
                             @method('DELETE')
-                            <input type="submit" value="削除" onClick="delete_alert(event);return false;">
+                            <input class="button" type="submit" value="削除" onClick="delete_alert(event);return false;">
                         </form>
                         <script>
                             function delete_alert(e){

--- a/resources/views/admin/account/index.blade.php
+++ b/resources/views/admin/account/index.blade.php
@@ -1,0 +1,44 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ '管理者アカウント一覧' }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @if (session('flash_message'))
+                <div class="flash_message">
+                    <p class="text-green-500">{{ session('flash_message') }}</p>
+                </div>
+            @endif
+            <button type="button" onclick="location.href='{{ route('admin.account.create') }}'">新規作成</button>
+            @foreach($admins as $admin)
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <p>氏名　：{{ $admin->name }}</p>
+                        <p>メール：{{ $admin->email }}</p>
+                        <p>作成日：{{ $admin->created_at }}</p>
+                    </div>
+                    <div class="p-6 text-gray-900">
+                        {{-- <button type="button" onclick="location.href='{{ route('admin.account.edit', $admin->id) }}'">編集</button> --}}
+                        <form method="POST" action="{{ route('admin.account.destroy', $admin->id) }}" style="display: inline">
+                            @csrf
+                            @method('DELETE')
+                            <input type="submit" value="削除" onClick="delete_alert(event);return false;">
+                        </form>
+                        <script>
+                            function delete_alert(e){
+                                if(!window.confirm('本当に削除しますか？')){
+                                    window.alert('キャンセルされました');
+                                    return false;
+                                }
+                                document.deleteform.submit();
+                            }
+                        </script>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/layouts/navigation.blade.php
+++ b/resources/views/admin/layouts/navigation.blade.php
@@ -13,7 +13,10 @@
                 <!-- Navigation Links -->
                 <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
                     <x-nav-link :href="route('admin.admin.dashboard')" :active="request()->routeIs('dashboard')">
-                        {{ __('Dashboard') }}
+                        {{ '管理画面' }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('admin.account.index')" :active="request()->routeIs('dashboard')" class="text-center">
+                        {!! '管理者<br>アカウント管理' !!}
                     </x-nav-link>
                 </div>
             </div>
@@ -50,50 +53,6 @@
                         </form>
                     </x-slot>
                 </x-dropdown>
-            </div>
-
-            <!-- Hamburger -->
-            <div class="-mr-2 flex items-center sm:hidden">
-                <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
-                    <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
-                        <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                        <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
-            </div>
-        </div>
-    </div>
-
-    <!-- Responsive Navigation Menu -->
-    <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
-        <div class="pt-2 pb-3 space-y-1">
-            <x-responsive-nav-link :href="route('admin.admin.dashboard')" :active="request()->routeIs('dashboard')">
-                {{ __('Dashboard') }}
-            </x-responsive-nav-link>
-        </div>
-
-        <!-- Responsive Settings Options -->
-        <div class="pt-4 pb-1 border-t border-gray-200">
-            <div class="px-4">
-                <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
-                <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
-            </div>
-
-            <div class="mt-3 space-y-1">
-                <x-responsive-nav-link :href="route('admin.profile.edit')">
-                    {{ __('Profile') }}
-                </x-responsive-nav-link>
-
-                <!-- Authentication -->
-                <form method="POST" action="{{ route('admin.logout') }}">
-                    @csrf
-
-                    <x-responsive-nav-link :href="route('admin.logout')"
-                            onclick="event.preventDefault();
-                                        this.closest('form').submit();">
-                        {{ __('Log Out') }}
-                    </x-responsive-nav-link>
-                </form>
             </div>
         </div>
     </div>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -84,6 +84,8 @@ Route::middleware('auth:admin')->group(function () {
     Route::get('/account', [AdminAccountController::class, 'index'])->name('account.index');
     Route::get('/account/create', [AdminAccountController::class, 'create'])->name('account.create');
     Route::post('/account', [AdminAccountController::class, 'store'])->name('account.store');
+    Route::get('/account/{id}/edit', [AdminAccountController::class, 'edit'])->name('account.edit');
+    Route::post('/account/{id}', [AdminAccountController::class, 'update'])->name('account.update');
     Route::delete('/account/{id}', [AdminAccountController::class, 'destroy'])->name('account.destroy');
 });
 

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -32,50 +32,24 @@ Route::get('/dashboard', function () {
 })->middleware(['auth:admin'])->name('admin.dashboard');
 
 Route::middleware('guest')->group(function () {
-    Route::get('register', [RegisteredAdminController::class, 'create'])
-                ->name('register');
-
+    Route::get('register', [RegisteredAdminController::class, 'create'])->name('register');
     Route::post('register', [RegisteredAdminController::class, 'store']);
-
-    Route::get('login', [AuthenticatedSessionController::class, 'create'])
-                ->name('login');
-
+    Route::get('login', [AuthenticatedSessionController::class, 'create'])->name('login');
     Route::post('login', [AuthenticatedSessionController::class, 'store']);
-
-    Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
-                ->name('password.request');
-
-    Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-                ->name('password.email');
-
-    Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])
-                ->name('password.reset');
-
-    Route::post('reset-password', [NewPasswordController::class, 'store'])
-                ->name('password.store');
+    Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])->name('password.request');
+    Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])->name('password.email');
+    Route::get('reset-password/{token}', [NewPasswordController::class, 'create'])->name('password.reset');
+    Route::post('reset-password', [NewPasswordController::class, 'store'])->name('password.store');
 });
 
 Route::middleware('auth:admin')->group(function () {
-    Route::get('verify-email', EmailVerificationPromptController::class)
-                ->name('verification.notice');
-
-    Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
-                ->middleware(['signed', 'throttle:6,1'])
-                ->name('verification.verify');
-
-    Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-                ->middleware('throttle:6,1')
-                ->name('verification.send');
-
-    Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
-                ->name('password.confirm');
-
+    Route::get('verify-email', EmailVerificationPromptController::class)->name('verification.notice');
+    Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)->middleware(['signed', 'throttle:6,1'])->name('verification.verify');
+    Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store'])->middleware('throttle:6,1')->name('verification.send');
+    Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])->name('password.confirm');
     Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
-
     Route::put('password', [PasswordController::class, 'update'])->name('password.update');
-
-    Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
-                ->name('logout');
+    Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])->name('logout');
     
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Admin\Auth\RegisteredAdminController;
 use App\Http\Controllers\Admin\Auth\VerifyEmailController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Admin\AdminAccountController;
 
 /*
 |--------------------------------------------------------------------------
@@ -29,12 +30,6 @@ Route::get('/', function () {
 Route::get('/dashboard', function () {
     return view('admin.dashboard');
 })->middleware(['auth:admin'])->name('admin.dashboard');
-
-Route::middleware('auth:admin')->group(function () {
-    Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
-    Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
-    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
-});
 
 Route::middleware('guest')->group(function () {
     Route::get('register', [RegisteredAdminController::class, 'create'])
@@ -81,5 +76,14 @@ Route::middleware('auth:admin')->group(function () {
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
                 ->name('logout');
+    
+    Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
+    Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
+    Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::get('/account', [AdminAccountController::class, 'index'])->name('account.index');
+    Route::get('/account/create', [AdminAccountController::class, 'create'])->name('account.create');
+    Route::post('/account', [AdminAccountController::class, 'store'])->name('account.store');
+    Route::delete('/account/{id}', [AdminAccountController::class, 'destroy'])->name('account.destroy');
 });
 


### PR DESCRIPTION
### Notion URL

https://www.notion.so/Admin-Admin-1d15eb1ab6a64995b87d272ce2f5f3e5

### タスク内容

Adminアカウントの作成・一覧・更新・削除
全て実装する。

### やったこと

- AdminAccountControllerを作成＋作成・一覧・更新・削除メソッドを定義
- ブレード「作成・一覧・更新・削除」を作成
- スタイル調整

### 動作確認

要件全て実装済み。（下記画像参照）

▼ アドミン一覧

> 現状登録されている管理者アカウントがリストとして全て表示される。
> 新規作成・編集・削除ボタンを設置し、クリックすると下記3機能画面へ推移する。

![Laravel (2)](https://github.com/tomonaganoriaki/Laravel__Training__DivingApp/assets/115410371/17029f96-6e90-4cc9-9d09-75940152d1c0)

▼ アドミン作成

> 管理者アカウントの新規作成が可能。
> SQLへの反映＋作成したアカウントでログインできるかまで動作確認済。

![Laravel (2)3](https://github.com/tomonaganoriaki/Laravel__Training__DivingApp/assets/115410371/f0a0a46a-7e39-401c-afc2-67589d9c8de8)

▼ アドミン更新

> 管理者アカウントの新規作成が可能。
> SQLへの反映＋編集したアカウントでログインできるかまで動作確認済。

![Laravel (2)56](https://github.com/tomonaganoriaki/Laravel__Training__DivingApp/assets/115410371/c6834937-bf8b-43ed-9912-269607d38e67)

▼ アドミン削除

> 削除ボタンを押すと確認アラートが表示され、OKを押すと削除される。
> 削除は論理削除で、DB（deleted_at）への反映も確認済。

![スクリーンショット 0005-11-12 0 27 34（4）](https://github.com/tomonaganoriaki/Laravel__Training__DivingApp/assets/115410371/aeb7289f-83c2-429b-a50a-1d4fced16da9)

### 備考

※上記キャプチャは見やすいように画面横幅を縮小しています！