### PR TITLE
DIVE-6x7x8　店舗・ニュース・ブランド管理機能の実装

### DIFF
--- a/app/Http/Controllers/Admin/BrandController.php
+++ b/app/Http/Controllers/Admin/BrandController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Brand;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class BrandController extends Controller
+{
+    public function index(): View
+    {
+        $brands = Brand::all();
+        return view('admin.brand.index')->with('brands', $brands);
+    }
+
+    public function create(): View
+    {
+        return view('admin.brand.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'name' => ['required', 'string', 'max:20'],
+        ]);
+        $brand = Brand::create([
+            'name' => $request->name,
+        ]);
+        session()->flash('flash_message', 'タグを作成しました。');
+        return redirect()->route('admin.brand.index');
+    }
+
+    public function edit($id): View
+    {
+        $brand = Brand::findOrFail($id);
+        return view('admin.brand.edit')->with('brand', $brand);
+    }
+
+    public function update(Request $request, $id): RedirectResponse
+    {
+        $brand = Brand::findOrFail($id);
+        $request->validate([
+            'name' => ['required', 'string', 'max:20'],
+        ]);
+        $brand->update([
+            'name' => $request->name,
+        ]);
+        session()->flash('flash_message', 'タグを更新しました。');
+        return redirect()->route('admin.brand.index');
+    }
+
+    public function destroy($id): RedirectResponse
+    {
+        $brand = Brand::findOrFail($id);
+        $brand->delete();
+        session()->flash('flash_message', 'タグを削除しました。');
+        return redirect()->route('admin.brand.index');
+    }
+}

--- a/app/Http/Controllers/Admin/BrandController.php
+++ b/app/Http/Controllers/Admin/BrandController.php
@@ -29,7 +29,7 @@ class BrandController extends Controller
         $brand = Brand::create([
             'name' => $request->name,
         ]);
-        session()->flash('flash_message', 'タグを作成しました。');
+        session()->flash('flash_message', 'ブランドを作成しました。');
         return redirect()->route('admin.brand.index');
     }
 
@@ -48,7 +48,7 @@ class BrandController extends Controller
         $brand->update([
             'name' => $request->name,
         ]);
-        session()->flash('flash_message', 'タグを更新しました。');
+        session()->flash('flash_message', 'ブランドを更新しました。');
         return redirect()->route('admin.brand.index');
     }
 
@@ -56,7 +56,7 @@ class BrandController extends Controller
     {
         $brand = Brand::findOrFail($id);
         $brand->delete();
-        session()->flash('flash_message', 'タグを削除しました。');
+        session()->flash('flash_message', 'ブランドを削除しました。');
         return redirect()->route('admin.brand.index');
     }
 }

--- a/app/Http/Controllers/Admin/NewsController.php
+++ b/app/Http/Controllers/Admin/NewsController.php
@@ -30,7 +30,7 @@ class NewsController extends Controller
             'title' => $request->title,
             'content' => $request->content,
         ]);
-        session()->flash('flash_message', 'タグを作成しました。');
+        session()->flash('flash_message', 'ニュースを作成しました。');
         return redirect()->route('admin.news.index');
     }
 
@@ -50,7 +50,7 @@ class NewsController extends Controller
             'title' => $request->title,
             'content' => $request->content,
         ]);
-        session()->flash('flash_message', 'タグを更新しました。');
+        session()->flash('flash_message', 'ニュースを更新しました。');
         return redirect()->route('admin.news.index');
     }
 
@@ -58,7 +58,7 @@ class NewsController extends Controller
     {
         $news = News::findOrFail($id);
         $news->delete();
-        session()->flash('flash_message', 'タグを削除しました。');
+        session()->flash('flash_message', 'ニュースを削除しました。');
         return redirect()->route('admin.news.index');
     }
 }

--- a/app/Http/Controllers/Admin/NewsController.php
+++ b/app/Http/Controllers/Admin/NewsController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\News;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class NewsController extends Controller
+{
+    public function index(): View
+    {
+        $news = News::all();
+        return view('admin.news.index')->with('newss', $news);
+    }
+
+    public function create(): View
+    {
+        return view('admin.news.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'title' => ['required', 'string', 'max:100'],
+        ]);
+        $news = News::create([
+            'title' => $request->title,
+            'content' => $request->content,
+        ]);
+        session()->flash('flash_message', 'タグを作成しました。');
+        return redirect()->route('admin.news.index');
+    }
+
+    public function edit($id): View
+    {
+        $news = News::findOrFail($id);
+        return view('admin.news.edit')->with('news', $news);
+    }
+
+    public function update(Request $request, $id): RedirectResponse
+    {
+        $news = News::findOrFail($id);
+        $request->validate([
+            'title' => ['required', 'string', 'max:100'],
+        ]);
+        $news->update([
+            'title' => $request->title,
+            'content' => $request->content,
+        ]);
+        session()->flash('flash_message', 'タグを更新しました。');
+        return redirect()->route('admin.news.index');
+    }
+
+    public function destroy($id): RedirectResponse
+    {
+        $news = News::findOrFail($id);
+        $news->delete();
+        session()->flash('flash_message', 'タグを削除しました。');
+        return redirect()->route('admin.news.index');
+    }
+}

--- a/app/Http/Controllers/Admin/ShopController.php
+++ b/app/Http/Controllers/Admin/ShopController.php
@@ -29,7 +29,7 @@ class ShopController extends Controller
         $shop = Shop::create([
             'name' => $request->name,
         ]);
-        session()->flash('flash_message', 'タグを作成しました。');
+        session()->flash('flash_message', '店舗を作成しました。');
         return redirect()->route('admin.shop.index');
     }
 
@@ -39,7 +39,7 @@ class ShopController extends Controller
         return view('admin.shop.edit')->with('shop', $shop);
     }
 
-    public function update(Request $request, $id): View
+    public function update(Request $request, $id): RedirectResponse
     {
         $shop = Shop::findOrFail($id);
         $request->validate([
@@ -48,7 +48,7 @@ class ShopController extends Controller
         $shop->update([
             'name' => $request->name,
         ]);
-        session()->flash('flash_message', 'タグを更新しました。');
+        session()->flash('flash_message', '店舗を更新しました。');
         return redirect()->route('admin.shop.index');
     }
 
@@ -56,7 +56,7 @@ class ShopController extends Controller
     {
         $shop = Shop::findOrFail($id);
         $shop->delete();
-        session()->flash('flash_message', 'タグを削除しました。');
+        session()->flash('flash_message', '店舗を削除しました。');
         return redirect()->route('admin.shop.index');
     }
 }

--- a/app/Http/Controllers/Admin/ShopController.php
+++ b/app/Http/Controllers/Admin/ShopController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Shop;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class ShopController extends Controller
+{
+    public function index(): View
+    {
+        $shops = Shop::all();
+        return view('admin.shop.index')->with('shops', $shops);
+    }
+
+    public function create(): View
+    {
+        return view('admin.shop.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'name' => ['required', 'string', 'max:20'],
+        ]);
+        $shop = Shop::create([
+            'name' => $request->name,
+        ]);
+        session()->flash('flash_message', 'タグを作成しました。');
+        return redirect()->route('admin.shop.index');
+    }
+
+    public function edit($id): View
+    {
+        $shop = Shop::findOrFail($id);
+        return view('admin.shop.edit')->with('shop', $shop);
+    }
+
+    public function update(Request $request, $id): View
+    {
+        $shop = Shop::findOrFail($id);
+        $request->validate([
+            'name' => ['required', 'string', 'max:20'],
+        ]);
+        $shop->update([
+            'name' => $request->name,
+        ]);
+        session()->flash('flash_message', 'タグを更新しました。');
+        return redirect()->route('admin.shop.index');
+    }
+
+    public function destroy($id): RedirectResponse
+    {
+        $shop = Shop::findOrFail($id);
+        $shop->delete();
+        session()->flash('flash_message', 'タグを削除しました。');
+        return redirect()->route('admin.shop.index');
+    }
+}

--- a/resources/views/admin/brand/create.blade.php
+++ b/resources/views/admin/brand/create.blade.php
@@ -1,0 +1,27 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ 'カテゴリー新規作成' }}
+        </h2>
+    </x-slot>
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST" action="{{ route('admin.brand.store') }}">
+                @csrf
+                <div>
+                    <x-input-label for="name" value="新カテゴリー名" />
+                    <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
+                    <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                </div>
+                <div class="flex items-center justify-end mt-4">
+                    <x-secondary-button onclick="location.href='{{ route('admin.brand.index') }}'">
+                        {{ __('Cancel') }}
+                    </x-secondary-button>
+                    <x-primary-button class="ml-4">
+                        {{ __('Register') }}
+                    </x-primary-button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/brand/edit.blade.php
+++ b/resources/views/admin/brand/edit.blade.php
@@ -1,0 +1,24 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ 'カテゴリー編集' }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST"  action="{{ route('admin.brand.update', $brand->id) }}">
+                @csrf
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900 pb-0">
+                        <p style="margin-bottom: 15px">ブランド名 ：　<input type="text" name="name" value="{{ $brand->name }}"></p>
+                    </div>
+                    <div class="p-6 text-gray-900">
+                        <input class="button" type="button" onclick="location.href='{{ route('admin.account.index') }}'" value="戻る" style="margin-right: 6px">
+                        <input class="button" type="submit" value="更新">
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/brand/index.blade.php
+++ b/resources/views/admin/brand/index.blade.php
@@ -1,0 +1,42 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ 'ブランド一覧' }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @if (session('flash_message'))
+                <div class="flash_message">
+                    <p class="text-green-500">{{ session('flash_message') }}</p>
+                </div>
+            @endif
+            <div style="text-align: right; margin-bottom:20px">
+                <button class="button" type="button" onclick="location.href='{{ route('admin.brand.create') }}'">新規作成</button>
+            </div>
+            @foreach($brands as $brand)
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <p>{{ $brand->name }}</p>
+                        <button class="button" type="button" onclick="location.href='{{ route('admin.brand.edit', $brand->id) }}'" style="margin-right: 6px">編集</button>
+                        <form method="POST" action="{{ route('admin.brand.destroy', $brand->id) }}" style="display: inline">
+                            @csrf
+                            @method('DELETE')
+                            <input class="button" type="submit" value="削除" onClick="delete_alert(event);return false;">
+                        </form>
+                        <script>
+                            function delete_alert(e){
+                                if(!window.confirm('本当に削除しますか？')){
+                                    window.alert('キャンセルされました');
+                                    return false;
+                                }
+                                document.deleteform.submit();
+                            }
+                        </script>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/layouts/navigation.blade.php
+++ b/resources/views/admin/layouts/navigation.blade.php
@@ -23,6 +23,7 @@
                     </x-nav-link>
                     <x-nav-link :href="route('admin.tag.index')" :active="request()->routeIs('dashboard')">
                         {{'タグ管理'}}
+                    </x-nav-link>
                     <x-nav-link :href="route('admin.shop.index')" :active="request()->routeIs('dashboard')">
                         {{'店舗管理'}}
                     </x-nav-link>

--- a/resources/views/admin/layouts/navigation.blade.php
+++ b/resources/views/admin/layouts/navigation.blade.php
@@ -19,7 +19,7 @@
                         {!! '管理者<br>アカウント管理' !!}
                     </x-nav-link>
                     <x-nav-link :href="route('admin.category.index')" :active="request()->routeIs('dashboard')" class="text-center">
-                        {!! 'カテゴリ<br>管理' !!}
+                        {!! 'カテゴリー<br>管理' !!}
                     </x-nav-link>
                     <x-nav-link :href="route('admin.tag.index')" :active="request()->routeIs('dashboard')">
                         {{'タグ管理'}}

--- a/resources/views/admin/layouts/navigation.blade.php
+++ b/resources/views/admin/layouts/navigation.blade.php
@@ -23,6 +23,14 @@
                     </x-nav-link>
                     <x-nav-link :href="route('admin.tag.index')" :active="request()->routeIs('dashboard')">
                         {{'タグ管理'}}
+                    <x-nav-link :href="route('admin.shop.index')" :active="request()->routeIs('dashboard')">
+                        {{'店舗管理'}}
+                    </x-nav-link>
+                    <x-nav-link :href="route('admin.news.index')" :active="request()->routeIs('dashboard')" class="text-center">
+                        {!! 'ニュース<br>管理' !!}
+                    </x-nav-link>
+                    <x-nav-link :href="route('admin.brand.index')" :active="request()->routeIs('dashboard')" class="text-center">
+                        {!! 'ブランド<br>管理' !!}
                     </x-nav-link>
                 </div>
             </div>

--- a/resources/views/admin/news/create.blade.php
+++ b/resources/views/admin/news/create.blade.php
@@ -1,0 +1,32 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ 'ニュース新規作成' }}
+        </h2>
+    </x-slot>
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST" action="{{ route('admin.news.store') }}">
+                @csrf
+                <div>
+                    <x-input-label for="title" value="タイトル" />
+                    <x-text-input id="title" class="block mt-1 w-full" type="text" name="title" :value="old('title')" required autofocus autocomplete="title" />
+                    <x-input-error :messages="$errors->get('title')" class="mt-2" />
+                </div>
+                <div class="mt-4">
+                    <x-input-label for="content" value="本文" />
+                    <x-text-input id="content" class="block mt-1 w-full" type="content" name="content" :value="old('content')" required autocomplete="content" />
+                    <x-input-error :messages="$errors->get('content')" class="mt-2" />
+                </div>
+                <div class="flex items-center justify-end mt-4">
+                    <x-secondary-button onclick="location.href='{{ route('admin.news.index') }}'">
+                        {{ __('Cancel') }}
+                    </x-secondary-button>
+                    <x-primary-button class="ml-4">
+                        {{ __('Register') }}
+                    </x-primary-button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/news/edit.blade.php
+++ b/resources/views/admin/news/edit.blade.php
@@ -1,0 +1,25 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ 'ニュース編集' }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST"  action="{{ route('admin.news.update', $news->id) }}">
+                @csrf
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900 pb-0">
+                        <p style="margin-bottom: 15px">タイトル：　<input type="text" name="title" value="{{ $news->title }}"></p>
+                        <p style="margin-bottom: 15px">本文　　：　<input type="text" name="content" value="{{ $news->content }}"></p>
+                    </div>
+                    <div class="p-6 text-gray-900">
+                        <input class="button" type="button" onclick="location.href='{{ route('admin.news.index') }}'" value="戻る" style="margin-right: 6px">
+                        <input class="button" type="submit" value="更新">
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/news/index.blade.php
+++ b/resources/views/admin/news/index.blade.php
@@ -1,0 +1,46 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ 'ニュース一覧' }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @if (session('flash_message'))
+                <div class="flash_message">
+                    <p class="text-green-500">{{ session('flash_message') }}</p>
+                </div>
+            @endif
+            <div style="text-align: right; margin-bottom:20px">
+                <button class="button" type="button" onclick="location.href='{{ route('admin.news.create') }}'">新規作成</button>
+            </div>
+            @foreach($newss as $news)
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <div style="margin-bottom: 15px">
+                            <p>題名　：{{ $news->title }}</p>
+                            <p>本文　：{{ $news->content }}</p>
+                            <p>更新日：{{ $news->updated_at }}</p>
+                        </div>
+                        <button class="button" type="button" onclick="location.href='{{ route('admin.news.edit', $news->id) }}'" style="margin-right: 6px">編集</button>
+                        <form method="POST" action="{{ route('admin.news.destroy', $news->id) }}" style="display: inline">
+                            @csrf
+                            @method('DELETE')
+                            <input class="button" type="submit" value="削除" onClick="delete_alert(event);return false;">
+                        </form>
+                        <script>
+                            function delete_alert(e){
+                                if(!window.confirm('本当に削除しますか？')){
+                                    window.alert('キャンセルされました');
+                                    return false;
+                                }
+                                document.deleteform.submit();
+                            }
+                        </script>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/shop/create.blade.php
+++ b/resources/views/admin/shop/create.blade.php
@@ -1,0 +1,27 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ '店舗新規作成' }}
+        </h2>
+    </x-slot>
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST" action="{{ route('admin.shop.store') }}">
+                @csrf
+                <div>
+                    <x-input-label for="name" value="新店舗名" />
+                    <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
+                    <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                </div>
+                <div class="flex items-center justify-end mt-4">
+                    <x-secondary-button onclick="location.href='{{ route('admin.shop.index') }}'">
+                        {{ __('Cancel') }}
+                    </x-secondary-button>
+                    <x-primary-button class="ml-4">
+                        {{ __('Register') }}
+                    </x-primary-button>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/shop/edit.blade.php
+++ b/resources/views/admin/shop/edit.blade.php
@@ -1,0 +1,24 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ '店舗編集' }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST"  action="{{ route('admin.shop.update', $shop->id) }}">
+                @csrf
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900 pb-0">
+                        <p style="margin-bottom: 15px">店舗名 ：　<input type="text" name="name" value="{{ $shop->name }}"></p>
+                    </div>
+                    <div class="p-6 text-gray-900">
+                        <input class="button" type="button" onclick="location.href='{{ route('admin.shop.index') }}'" value="戻る" style="margin-right: 6px">
+                        <input class="button" type="submit" value="更新">
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/shop/index.blade.php
+++ b/resources/views/admin/shop/index.blade.php
@@ -1,0 +1,42 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ '店舗一覧' }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12 font-bold">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @if (session('flash_message'))
+                <div class="flash_message">
+                    <p class="text-green-500">{{ session('flash_message') }}</p>
+                </div>
+            @endif
+            <div style="text-align: right; margin-bottom:20px">
+                <button class="button" type="button" onclick="location.href='{{ route('admin.shop.create') }}'">新規作成</button>
+            </div>
+            @foreach($shops as $shop)
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-gray-900">
+                        <p>{{ $shop->name }}</p>
+                        <button class="button" type="button" onclick="location.href='{{ route('admin.shop.edit', $shop->id) }}'" style="margin-right: 6px">編集</button>
+                        <form method="POST" action="{{ route('admin.shop.destroy', $shop->id) }}" style="display: inline">
+                            @csrf
+                            @method('DELETE')
+                            <input class="button" type="submit" value="削除" onClick="delete_alert(event);return false;">
+                        </form>
+                        <script>
+                            function delete_alert(e){
+                                if(!window.confirm('本当に削除しますか？')){
+                                    window.alert('キャンセルされました');
+                                    return false;
+                                }
+                                document.deleteform.submit();
+                            }
+                        </script>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -13,6 +13,9 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Admin\AdminAccountController;
 use App\Http\Controllers\Admin\CategoryController;
 use App\Http\Controllers\Admin\TagController;
+use App\Http\Controllers\Admin\ShopController;
+use App\Http\Controllers\Admin\NewsController;
+use App\Http\Controllers\Admin\BrandController;
 
 /*
 |--------------------------------------------------------------------------
@@ -77,5 +80,26 @@ Route::middleware('auth:admin')->group(function () {
     Route::get('/tag/{id}/edit', [TagController::class, 'edit'])->name('tag.edit')->where('id', '[0-9]+');
     Route::post('/tag/{id}', [TagController::class, 'update'])->name('tag.update')->where('id', '[0-9]+');
     Route::delete('/tag/{id}', [TagController::class, 'destroy'])->name('tag.destroy')->where('id', '[0-9]+');
+
+    Route::get('/shop', [ShopController::class, 'index'])->name('shop.index')->where('id', '[0-9]+');;
+    Route::get('/shop/create', [ShopController::class, 'create'])->name('shop.create')->where('id', '[0-9]+');;
+    Route::post('/shop', [ShopController::class, 'store'])->name('shop.store')->where('id', '[0-9]+');;
+    Route::get('/shop/{id}/edit', [ShopController::class, 'edit'])->name('shop.edit')->where('id', '[0-9]+');;
+    Route::post('/shop/{id}', [ShopController::class, 'update'])->name('shop.update')->where('id', '[0-9]+');;
+    Route::delete('/shop/{id}', [ShopController::class, 'destroy'])->name('shop.destroy')->where('id', '[0-9]+');;
+
+    Route::get('/news', [NewsController::class, 'index'])->name('news.index')->where('id', '[0-9]+');;
+    Route::get('/news/create', [NewsController::class, 'create'])->name('news.create')->where('id', '[0-9]+');;
+    Route::post('/news', [NewsController::class, 'store'])->name('news.store')->where('id', '[0-9]+');;
+    Route::get('/news/{id}/edit', [NewsController::class, 'edit'])->name('news.edit')->where('id', '[0-9]+');;
+    Route::post('/news/{id}', [NewsController::class, 'update'])->name('news.update')->where('id', '[0-9]+');;
+    Route::delete('/news/{id}', [NewsController::class, 'destroy'])->name('news.destroy')->where('id', '[0-9]+');;
+
+    Route::get('/brand', [BrandController::class, 'index'])->name('brand.index')->where('id', '[0-9]+');;
+    Route::get('/brand/create', [BrandController::class, 'create'])->name('brand.create')->where('id', '[0-9]+');;
+    Route::post('/brand', [BrandController::class, 'store'])->name('brand.store')->where('id', '[0-9]+');;
+    Route::get('/brand/{id}/edit', [BrandController::class, 'edit'])->name('brand.edit')->where('id', '[0-9]+');;
+    Route::post('/brand/{id}', [BrandController::class, 'update'])->name('brand.update')->where('id', '[0-9]+');;
+    Route::delete('/brand/{id}', [BrandController::class, 'destroy'])->name('brand.destroy')->where('id', '[0-9]+');;
 });
 


### PR DESCRIPTION
### Notion URL / タスク内容

- [DIVE-6](https://www.notion.so/Admin-746b8fcd4d0b456199bdd976f0f73aca?pvs=4)：店舗管理
- [DIVE-7](https://www.notion.so/Admin-c081f9e3930d4b33865d966611903ba0?pvs=4)：ニュース管理
- [DIVE-8](https://www.notion.so/Admin-881bd2fe61a14c2dafe0059871ba7757?pvs=4)：ブランド管理

### やったこと

[DIVE-3](https://github.com/tomonaganoriaki/Laravel__Training__DivingApp/pull/4)〜[DIVE-5](https://github.com/tomonaganoriaki/Laravel__Training__DivingApp/pull/5)と類似処理を実行。

### 動作確認

コンフリクト対応もしたため、「管理者アカウント」「カテゴリ」「タグ」「店舗」「ニュース」「ブランド」全てで新規作成・編集・削除が出来るかを確認。DBも確認済。

▼ 一例：新規ニュース管理機能
![Laravel (2)](https://github.com/tomonaganoriaki/Laravel__Training__DivingApp/assets/115410371/e7f83ab6-6508-4256-b78f-403747e503b7)

### 備考

スケジュールの都合でDIVE6~8を同ブランチで実装しております。